### PR TITLE
[WIP] Add sparse matrix support to Frustratometer and frustration.py

### DIFF
--- a/frustratometer/classes/Frustratometer.py
+++ b/frustratometer/classes/Frustratometer.py
@@ -421,7 +421,6 @@ class Frustratometer:
                                       -self.frustration(kind=single, sequence=sequence, aa_freq=aa_freq),
                                       -self.frustration(kind=pair, sequence=sequence, aa_freq=aa_freq),
                                       max_connections=max_connections, movie_name=movie_name, still_image_name=still_image_name)
-        frustration.call_vmd(self.pdb_file, tcl_script)
         if call_vmd:
             frustration.call_vmd(self.pdb_file, tcl_script)
 

--- a/frustratometer/classes/Frustratometer.py
+++ b/frustratometer/classes/Frustratometer.py
@@ -390,7 +390,8 @@ class Frustratometer:
         return frustration.compute_auc(self.roc())
 
     def vmd(self, sequence: str = None, single:Union[str,np.array] = 'singleresidue', pair:Union[str,np.array] = 'mutational',
-             aa_freq:np.array = None, correction:int = 0, max_connections:Union[int,None] = None, movie_name=None, still_image_name=None):
+             aa_freq:np.array = None, correction:int = 0, max_connections:Union[int,None] = None, movie_name=None, still_image_name=None,
+             call_vmd: bool = True):
         """
         Calculates frustration indices and superimposes frustration patterns onto PDB structure using the VMD software.
 

--- a/frustratometer/classes/Frustratometer.py
+++ b/frustratometer/classes/Frustratometer.py
@@ -421,6 +421,8 @@ class Frustratometer:
                                       -self.frustration(kind=pair, sequence=sequence, aa_freq=aa_freq),
                                       max_connections=max_connections, movie_name=movie_name, still_image_name=still_image_name)
         frustration.call_vmd(self.pdb_file, tcl_script)
+        if call_vmd:
+            frustration.call_vmd(self.pdb_file, tcl_script)
 
     def view_pair_frustration(self, sequence:str = None, pair:str = 'mutational', aa_freq:np.array = None):
         """

--- a/frustratometer/classes/Frustratometer.py
+++ b/frustratometer/classes/Frustratometer.py
@@ -51,6 +51,20 @@ class Frustratometer:
         """True when a sparse Potts model is available."""
         return getattr(self, 'sparse_potts_model', None) is not None
 
+    def _get_mask_mean(self):
+        """Get the mean value of the mask, handling both sparse and dense formats."""
+        from .Structure import SparseMatrix as _SM
+        if isinstance(self.mask, _SM):
+            # For sparse mask, compute the mean analytically
+            return frustration.mask_mean(
+                self.mask.shape,
+                minimum_sequence_separation=getattr(self, 'sequence_cutoff', None),
+                chain_breaks=getattr(self, 'chain_breaks', None)
+            )
+        else:
+            # Dense mask: compute mean directly
+            return float(self.mask.mean())
+
     def _compute_native_energy_elec(self, sequence, elec_data):
         """Dispatch electrostatic native energy to sparse or dense version."""
         if elec_data.get('indicator') is None:
@@ -222,14 +236,8 @@ class Frustratometer:
                 if _elec_data is not None:
                     fluctuation = frustration.apply_elec_correction_mutational(fluctuation, self.sparse_potts_model, _elec_data)
             elif kind == 'pseudoconfigurational':
-                from .Structure import SparseMatrix as _SM
-                if isinstance(self.mask, _SM):
-                    if self.distance_cutoff is None:
-                        _mask_mean = frustration.mask_mean(self.mask.shape, self.sequence_cutoff, self.chain_breaks)
-                    else:
-                        _mask_mean = float(len(self.mask)) / (self.mask.shape * self.mask.shape)
-                else:
-                    _mask_mean = float(self.mask.mean())
+                # Use the helper method to get mask mean, handling both sparse and dense
+                _mask_mean = self._get_mask_mean()
                 fluctuation = frustration.compute_pseudoconfigurational_decoy_energy_fluctuation_sparse(sequence, self.sparse_potts_model, _mask_mean)
                 if _elec_data is not None:
                     fluctuation = frustration.apply_elec_correction_pseudoconfigurational(fluctuation, self.sparse_potts_model, _elec_data)
@@ -439,6 +447,7 @@ class Frustratometer:
             Array of frequencies of all 21 possible amino acids within sequence
         """
         import py3Dmol
+        from .Structure import SparseMatrix as _SM
 
         if sequence is None:
             sequence=self.sequence
@@ -446,11 +455,22 @@ class Frustratometer:
         pdb_filename = self.pdb_file
         shift=self.init_index_shift+1
 
-        pair_frustration=self.frustration(sequence=sequence, kind=pair)*np.triu(self.mask)
-        residues=np.arange(len(sequence))
-
-        r1, r2 = np.meshgrid(residues, residues, indexing='ij')
-        sel_frustration = np.array([r1.ravel(), r2.ravel(), pair_frustration.ravel()]).T
+        pair_frustration = self.frustration(sequence=sequence, kind=pair)
+        
+        # Handle sparse or dense mask/frustration
+        if isinstance(self.mask, _SM):
+            # Sparse mask - iterate only over stored pairs
+            mask_indices_i = self.mask.row
+            mask_indices_j = self.mask.col
+            pair_frust_values = pair_frustration[mask_indices_i, mask_indices_j] if isinstance(pair_frustration, np.ndarray) else np.array([pair_frustration[i, j] if pair_frustration[i, j] is not None else 0 for i, j in zip(mask_indices_i, mask_indices_j)])
+            sel_frustration = np.column_stack((mask_indices_i, mask_indices_j, pair_frust_values))
+        else:
+            # Dense mask - use meshgrid as before
+            residues = np.arange(len(sequence))
+            r1, r2 = np.meshgrid(residues, residues, indexing='ij')
+            pair_frustration_triu = pair_frustration * np.triu(self.mask)
+            sel_frustration = np.array([r1.ravel(), r2.ravel(), pair_frustration_triu.ravel()]).T
+        
         minimally_frustrated = sel_frustration[sel_frustration[:, -1] > 1]
         frustrated = sel_frustration[sel_frustration[:, -1] < -self.minimally_frustrated_threshold]
         
@@ -549,6 +569,8 @@ class Frustratometer:
         r_m : np.array
             Array of midpoints between evaluated spherical shells
         """
+        from .Structure import SparseMatrix as _SM
+
         if sequence==None:
             sequence=self.sequence
         frustration_values=self.frustration(sequence=sequence,kind=kind)
@@ -564,9 +586,19 @@ class Frustratometer:
             sel_frustration = np.column_stack((residue_cb_coordinates,np.expand_dims(frustration_values, axis=1)))
             
         elif kind in ["configurational","pseudoconfigurational","mutational"]:
-            i,j=np.meshgrid(range(0,len(self.sequence)),range(0,len(self.sequence)))
-            midpoint_coordinates=(residue_cb_coordinates[i.flatten(),:]+ residue_cb_coordinates[j.flatten(),:])/2
-            sel_frustration = np.column_stack((midpoint_coordinates, frustration_values.ravel()))
+            # Handle sparse or dense frustration matrix
+            if isinstance(frustration_values, _SM):
+                # For sparse frustration, only compute coordinates for stored pairs
+                i_indices = frustration_values.row
+                j_indices = frustration_values.col
+                frust_vals = frustration_values.data if frustration_values.data is not None else np.ones(len(i_indices))
+                midpoint_coords = (residue_cb_coordinates[i_indices, :] + residue_cb_coordinates[j_indices, :]) / 2
+                sel_frustration = np.column_stack((midpoint_coords, frust_vals))
+            else:
+                # Dense frustration - use full meshgrid
+                i,j=np.meshgrid(range(0,len(self.sequence)),range(0,len(self.sequence)))
+                midpoint_coordinates=(residue_cb_coordinates[i.flatten(),:]+ residue_cb_coordinates[j.flatten(),:])/2
+                sel_frustration = np.column_stack((midpoint_coordinates, frustration_values.ravel()))
 
         r=np.linspace(1,maximum_shell_radius,bins)
         r_m=(r[1:]+r[:-1])/2

--- a/frustratometer/frustration/frustration.py
+++ b/frustratometer/frustration/frustration.py
@@ -890,10 +890,12 @@ def plot_singleresidue_decoy_energy(decoy_energy, native_energy, method='cluster
     return g
 
 
-def write_tcl_script(pdb_file: Union[Path,str], chain: str, mask: np.array, distance_matrix: np.array, distance_cutoff: float, single_frustration: np.array,
+def write_tcl_script(pdb_file: Union[Path,str], chain: str, mask, distance_matrix, distance_cutoff: float, single_frustration: np.array,
                     pair_frustration: np.array, tcl_script: Union[Path, str] ='frustration.tcl',max_connections: int =None, movie_name: Union[Path, str] =None, still_image_name: Union[Path, str] =None) -> Union[Path, str]:
     """
     Writes a tcl script that can be run with VMD to superimpose the frustration patterns onto the corresponding PDB structure. 
+    
+    Supports both dense and sparse matrices for mask and distance_matrix.
 
     Parameters
     ----------
@@ -901,10 +903,11 @@ def write_tcl_script(pdb_file: Union[Path,str], chain: str, mask: np.array, dist
         pdb file name
     chain : str
         Select chain from pdb
-    mask : np.array
-        A 2D Boolean array that determines which residue pairs should be considered in the energy computation. The mask should have dimensions (L, L), where L is the length of the sequence.
-    distance_matrix : np.array
-        LxL array for sequence of length L, describing distances between contacts
+    mask : np.array or SparseMatrix
+        A 2D Boolean array or SparseMatrix that determines which residue pairs should be considered in the energy computation.
+        If dense, should have dimensions (L, L) where L is the sequence length.
+    distance_matrix : np.array or SparseMatrix
+        Distance matrix (dense or sparse) for sequence of length L, describing distances between contacts
     distance_cutoff : float
         Maximum distance at which a contact occurs
     single_frustration : np.array
@@ -926,6 +929,12 @@ def write_tcl_script(pdb_file: Union[Path,str], chain: str, mask: np.array, dist
     tcl_script : Path or str
         tcl script file
     """
+    # Import SparseMatrix locally to avoid circular imports
+    try:
+        from frustratometer.classes.Structure import SparseMatrix as _SM
+    except ImportError:
+        _SM = None
+    
     fo = open(tcl_script, 'w+')
     single_frustration = np.nan_to_num(single_frustration,nan=0,posinf=0,neginf=0)
     pair_frustration = np.nan_to_num(pair_frustration,nan=0,posinf=0,neginf=0)
@@ -941,15 +950,49 @@ def write_tcl_script(pdb_file: Union[Path,str], chain: str, mask: np.array, dist
         # print(f)
         fo.write(f'[atomselect top "residue {int(r)}"] set beta {f}\n')
 
-    # Mutational frustration:
-    r1, r2 = np.meshgrid(residues, residues, indexing='ij')
-    sel_frustration = np.array([r1.ravel(), r2.ravel(), pair_frustration.ravel(),distance_matrix.ravel(), mask.ravel()]).T
-    #Filter with mask and distance
+    # Mutational frustration: Handle both sparse and dense matrices
+    # Build sel_frustration from sparse or dense data
+    if _SM is not None and isinstance(mask, _SM) and isinstance(distance_matrix, _SM):
+        # Both are sparse - work directly with sparse indices
+        mask_i = mask.row
+        mask_j = mask.col
+        
+        # Look up distances and frustrations for mask pairs
+        distances = np.array([distance_matrix.lookup(i, j) for i, j in zip(mask_i, mask_j)])
+        frustrations = np.array([pair_frustration[i, j] for i, j in zip(mask_i, mask_j)])
+        
+        # Create array: [i, j, frustration, distance, mask_value]
+        # mask_value is always 1 (since we're only iterating over mask pairs)
+        sel_frustration = np.column_stack((mask_i, mask_j, frustrations, distances, np.ones(len(mask_i))))
+    elif _SM is not None and isinstance(mask, _SM):
+        # mask is sparse, distance_matrix is dense
+        mask_i = mask.row
+        mask_j = mask.col
+        distances = distance_matrix[mask_i, mask_j]
+        frustrations = np.array([pair_frustration[i, j] for i, j in zip(mask_i, mask_j)])
+        sel_frustration = np.column_stack((mask_i, mask_j, frustrations, distances, np.ones(len(mask_i))))
+    elif _SM is not None and isinstance(distance_matrix, _SM):
+        # distance_matrix is sparse, mask is dense
+        r1, r2 = np.meshgrid(residues, residues, indexing='ij')
+        mask_indices = np.where(mask)
+        sel_frustration = np.column_stack((
+            mask_indices[0],
+            mask_indices[1],
+            pair_frustration[mask_indices],
+            np.array([distance_matrix.lookup(i, j) for i, j in zip(mask_indices[0], mask_indices[1])]),
+            mask[mask_indices]
+        ))
+    else:
+        # Both are dense (original code)
+        r1, r2 = np.meshgrid(residues, residues, indexing='ij')
+        sel_frustration = np.array([r1.ravel(), r2.ravel(), pair_frustration.ravel(),distance_matrix.ravel(), mask.ravel()]).T
+    
+    # Filter with mask and distance
     if distance_cutoff:
-        mask_dist=(sel_frustration[:, -2] <= distance_cutoff)
+        mask_dist=(sel_frustration[:, 3] <= distance_cutoff)  # distance is at index 3
     else:
         mask_dist=np.ones(len(sel_frustration),dtype=bool)
-    sel_frustration = sel_frustration[mask_dist & (sel_frustration[:, -1] > 0)]
+    sel_frustration = sel_frustration[mask_dist & (sel_frustration[:, 4] > 0)]  # mask value is at index 4
     
     minimally_frustrated = sel_frustration[sel_frustration[:, 2] < -0.78]
     #minimally_frustrated = sel_frustration[sel_frustration[:, 2] < -1.78]

--- a/frustratometer/frustration/frustration.py
+++ b/frustratometer/frustration/frustration.py
@@ -964,6 +964,8 @@ def write_tcl_script(pdb_file: Union[Path,str], chain: str, mask, distance_matri
     for r, f in zip(residues, single_frustration):
         fo.write(f'[atomselect top "residue {int(r)}"] set beta {f}\n')
 
+    # creating ii and jj could be an issue if we have a huge distance 
+    # matrix, but such a use case seems very unlikely
     ii, jj = np.triu_indices(len(residues), k=1)
 
     # even though having a RAM-challening distance matrix
@@ -1022,8 +1024,17 @@ def write_tcl_script(pdb_file: Union[Path,str], chain: str, mask, distance_matri
         keep &= (dist_all <= distance_cutoff)
 
     ii, jj = ii[keep], jj[keep]
-    frust = pair_frustration[ii, jj]
-    dist = distance_matrix[ii, jj]
+
+    # Fetch frustration and distance values for the kept pairs in a sparse-aware way
+    if _SM is not None and isinstance(pair_frustration, _SM):
+        frust = _sparse_lookup_default(pair_frustration, ii, jj, default=0.0)
+    else:
+        frust = np.asarray(pair_frustration)[ii, jj]
+
+    if _SM is not None and isinstance(distance_matrix, _SM):
+        dist = _sparse_lookup_default(distance_matrix, ii, jj, default=np.inf)
+    else:
+        dist = np.asarray(distance_matrix)[ii, jj]
 
     # Green = minimally frustrated (most negative first); red = frustrated (most positive
     # first). For each: sort, cap at max_connections, then draw the in-range contacts.


### PR DESCRIPTION
## Description
Sparse `Structure`s/`Frustratometer`s are breaking some of the utility functions. This seems to fix things, at least for my simple use case of writing a tcl script to make the frustratogram in VMD. I also added a function parameter to control whether VMD is launched automatically after writing the tcl script.